### PR TITLE
[Server] Support routines dynamic context allocation

### DIFF
--- a/server/src/bootstraps/runner.js
+++ b/server/src/bootstraps/runner.js
@@ -27,6 +27,7 @@ import type {Argv} from '../Config';
 const Config = require('../Config');
 const Runner = require('../services/Runner');
 
+const CTX_ID_KEY = 'ctx-id';
 const SCRIPT_ID_KEY = 'script-id';
 
 const on_init = function(runner: Runner) {
@@ -36,10 +37,12 @@ const on_init = function(runner: Runner) {
 
 const bootstrap = function(argv: Argv): Runner {
   console.assert(argv.has(SCRIPT_ID_KEY), `Missing reqired parameter --${SCRIPT_ID_KEY}`);
+  console.assert(argv.has(CTX_ID_KEY), `Missing reqired parameter --${CTX_ID_KEY}`);
 
   const script_id = argv.get(SCRIPT_ID_KEY);
+  const ctx_id = argv.get(CTX_ID_KEY);
   const config = Config.fromArgv(argv);
-  const runner = new Runner(config, script_id.toString());
+  const runner = new Runner(config, script_id.toString(), ctx_id.toString());
   runner.on(Runner.events.INIT, () => on_init(runner));
 
   return runner;

--- a/server/src/model/Script.js
+++ b/server/src/model/Script.js
@@ -24,16 +24,17 @@
 
 const Mongoose = require('mongoose');
 const scriptSchema = new Mongoose.Schema({
-  title: { type: String, required: true },
   code: { type: String, required: true },
+  context_type: { type: String, required: true },
+  created_time: { type: Date },
   optimisations: { type: Object, default: [] },
-  createdTime: { type: Date },
-  updatedTime: { type: Date },
+  title: { type: String, required: true },
+  updated_time: { type: Date },
 });
 
 scriptSchema.pre('save', function(next) {
-  this.updatedTime = new Date();
-  this.createdTime = this.createdTime || this.updatedTime;
+  this.updated_time = new Date();
+  this.created_time = this.created_time || this.updated_time;
   next();
 });
 

--- a/server/src/sandbox/template.js
+++ b/server/src/sandbox/template.js
@@ -38,7 +38,7 @@ const {Map} = require('immutable');
 
 const {getObject} = require('./GraphSchemaLoader');
 
-module.exports = function(config: Config, script: Document): Object {
+module.exports = function(config: Config, script: Document, ctx_id: string): Object {
   // Load configs
   const app_id = config.getInteger('graph.application_id');
   const app_secret = config.getString('graph.application_secret');
@@ -63,9 +63,9 @@ module.exports = function(config: Config, script: Document): Object {
   const api = new Api(new Adapter(), optimizer, session, graph_versions);
 
   // Init context
-  const ctx = Node.fromSpec(api, registry.get('AdAccount'));
+  const ctx = Node.fromSpec(api, registry.get(script.get('context_type')));
   // FLOW_UNSAFE
-  ctx.id = config.getString('DEPRECATED__cxt_id');
+  ctx.id = ctx_id;
 
   return {
     api: api, // FIXME should this be directly exposed ?

--- a/server/src/scheduler/Queue.js
+++ b/server/src/scheduler/Queue.js
@@ -65,8 +65,9 @@ class Queue {
     return this;
   }
 
-  createRoutine(script_id: string, date: Date, callback?: OnScheduleCallback): this {
+  createRoutine(script_id: string, ctx_id: string, date: Date, callback?: OnScheduleCallback): this {
     const document = this.getModel()({
+      context_id: ctx_id,
       script_id: script_id,
       visible_from: date,
     });

--- a/server/src/scheduler/RoutineSchema.js
+++ b/server/src/scheduler/RoutineSchema.js
@@ -31,6 +31,7 @@ export interface LogEntry {
 
 const Mongoose = require('mongoose');
 const schema = new Mongoose.Schema({
+  context_id: { type: String, required: true },
   creation_time: { type: Date },
   is_completed: { type: Boolean, default: false },
   lock_creation_time: { type: Date, default: null },

--- a/server/src/scheduler/Scheduler.js
+++ b/server/src/scheduler/Scheduler.js
@@ -70,19 +70,19 @@ class Scheduler {
     return new List([this.getHighPriQueue(), this.getQueue()]);
   }
 
-  enqueue(queue: Queue, script_id: string, date: Date, callback?: OnScheduleCallback): this {
-    queue.createRoutine(script_id, date, callback);
+  enqueue(queue: Queue, script_id: string, ctx_id: string, date: Date, callback?: OnScheduleCallback): this {
+    queue.createRoutine(script_id, ctx_id, date, callback);
 
     return this;
   }
 
-  schedule(script_id: string, date: Date, callback?: OnScheduleCallback): this {
-    return this.enqueue(this.getQueue(), script_id, date, callback);
+  schedule(script_id: string, ctx_id: string, date: Date, callback?: OnScheduleCallback): this {
+    return this.enqueue(this.getQueue(), script_id, ctx_id, date, callback);
   }
 
   // Will schedule on the hi-pri queue
-  exec(script_id: string, callback?: OnScheduleCallback): this {
-    return this.enqueue(this.getHighPriQueue(), script_id, new Date(), callback);
+  exec(script_id: string, ctx_id: string, callback?: OnScheduleCallback): this {
+    return this.enqueue(this.getHighPriQueue(), script_id, ctx_id, new Date(), callback);
   }
 
   getRoutine(id: string, callback: OnRoutineContextualizedCallback): this {

--- a/server/src/server/controllers/routine/RoutineCreateController.js
+++ b/server/src/server/controllers/routine/RoutineCreateController.js
@@ -43,6 +43,8 @@ class RoutineCreateController extends AbstractController {
 
   genResponse(context: Context): void {
     const script_id = context.getRequest().body.script_id.toString();
+    // FIXME provide context from client
+    const ctx_id = this.getApplication().getConfig().getString('DEPRECATED__cxt_id');
 
     context.execPromise(Script.findById(script_id).exec())
       .then((script: ?Document) => {
@@ -51,6 +53,7 @@ class RoutineCreateController extends AbstractController {
         } else {
           this.getApplication().getScheduler().exec(
             script_id,
+            ctx_id,
             (routine: Document) => { context.sendDocument(routine); }
           );
         }

--- a/server/src/server/controllers/script/ScriptCreateController.js
+++ b/server/src/server/controllers/script/ScriptCreateController.js
@@ -47,6 +47,8 @@ class ScriptCreateController extends AbstractDocumentCreateController {
       title: body.title,
       optimisations: body.optimisations,
       code: body.code,
+      // FIXME provide context type from client
+      context_type: 'AdAccount',
     });
 
     context.execPromise(script.save()).then((script: Document) => {

--- a/server/src/services/Runner.js
+++ b/server/src/services/Runner.js
@@ -34,18 +34,24 @@ const sandbox_template = require('../sandbox/template');
 // implement ServiceInterface
 class Runner extends AbstractService {
 
+  contextId: string;
   sandbox: Sandbox;
   scriptId: string;
 
-  constructor(config: Config, script_id: string): void {
+  constructor(config: Config, script_id: string, ctx_id: string): void {
     super(config);
     this.sandbox = new Sandbox();
     this.sandbox.setTimeout(config.getInteger('sandbox.timeout'));
+    this.contextId = ctx_id;
     this.scriptId = script_id;
   }
 
   getSandbox(): Sandbox {
     return this.sandbox;
+  }
+
+  getContextId(): string {
+    return this.contextId;
   }
 
   getScriptId(): string {
@@ -61,7 +67,7 @@ class Runner extends AbstractService {
       if (script == null) {
         throw new Error(`Unknown script ${script_id}`);
       }
-      this.getSandbox().setSharedObject(sandbox_template(this.getConfig(), script));
+      this.getSandbox().setSharedObject(sandbox_template(this.getConfig(), script, this.getContextId()));
       this.emit(Runner.events.INIT);
       // Prioritize service listeners as sanxbox execute syncronously
       process.nextTick(() => {

--- a/server/src/services/Worker.js
+++ b/server/src/services/Worker.js
@@ -72,9 +72,10 @@ class Worker extends AbstractService {
   ): void {
     const id = routine.get('id');
     const script_id = routine.get('script_id');
+    const ctx_id = routine.get('context_id');
 
     // FIXME no transpile by default
-    const argv = ['index.js', '--transpile', '--mode', 'runner', '--script-id', script_id];
+    const argv = ['index.js', '--transpile', '--mode', 'runner', '--script-id', script_id, '--ctx-id', ctx_id];
     const child = execFile('node', argv);
 
     this.log(`Routine ${id} Started`);


### PR DESCRIPTION
- Script schema to carry context type, ie: AdAccount
- Routine schema to carry context id, ie: act_*
- Keep hardcoded type to AdAccount + DEPRECATED__cxt_id at controller level -> client to solve, providing dat through API
- Fix Script model key naming convention
