### PR TITLE
[SDK] implement an implicit logic to paginate over cursors

### DIFF
--- a/sdk/__tests__/http/Request-test.js
+++ b/sdk/__tests__/http/Request-test.js
@@ -95,4 +95,15 @@ describe('Request', () => {
     request.getApi().execRequest.mockReturnValue(response);
     expect(request.execute()).toBe(response);
   });
+
+  it('can generate copies of itself with references to new disposable objects', () => {
+    const request = makeRequest();
+    const copy = request.getCopy();
+    expect(copy).toEqual(jasmine.any(Request));
+    expect(copy).not.toBe(request);
+    expect(copy.getApi()).toBe(request.getApi());
+    expect(copy.getPath()).toEqual(request.getPath());
+    expect(copy.getMethod()).toEqual(request.getMethod());
+    expect(copy.getParams().toJS()).toEqual(request.getParams().toJS());
+  });
 });

--- a/sdk/src/http/Request.js
+++ b/sdk/src/http/Request.js
@@ -128,6 +128,10 @@ class Request {
       : null;
   }
 
+  getCopy(): Request {
+    return new Request(this.getApi(), this.getPath(), this.getMethod(), this.getParams());
+  }
+
   execute(): Response {
     return this.getApi().execRequest(this);
   }


### PR DESCRIPTION
Note: providing a limit parameter will perform an initial request for a page of that size and disable pagination.
