### PR TITLE
[Server] Implement a crontab-like schedule recurrence interface

### DIFF
--- a/client/src/js/components/TypeFastHistoryModal.js
+++ b/client/src/js/components/TypeFastHistoryModal.js
@@ -64,7 +64,7 @@ class TypeFastHistoryModal extends React.Component {
           {this.props.routines.map(curr =>
             <ListItem
               key={curr.id}
-              primaryText={curr.creation_time}
+              primaryText={curr.visible_from}
               initiallyOpen={false}
               nestedItems={[
                 <TypeFastCustomListItem key={0}>

--- a/server/src/bootstraps/server.js
+++ b/server/src/bootstraps/server.js
@@ -33,12 +33,12 @@ const getControllers = require('../server/controllersFactory');
 const bootstrap = function(argv: Argv): Application {
   const app = new Application(Config.fromArgv(argv));
   getControllers(app).forEach(controller => app.getRouter().mountCountroller(controller));
-  app.on(Application.events.INIT, ((drivers: Map<string, AbstractDriver>) => {
+  app.on(Application.events.INIT, (drivers: Map<string, AbstractDriver>) => {
     drivers.map((driver: AbstractDriver, key: string) => {
       const listener = driver.getListenerDescription();
       console.log(`Server listening on [${key}]: ${listener}`);
     });
-  }));
+  });
   return app;
 };
 

--- a/server/src/model/schema/schedule.js
+++ b/server/src/model/schema/schedule.js
@@ -28,7 +28,7 @@ const schema = new Mongoose.Schema({
   creation_time: { type: Date },
   start_time: { type: Date },
   is_paused: { type: Boolean, default: false, required: true },
-  recurrence: { type: Number, default: 0 },
+  recurrence: { type: Object, value: { type: Array, value: { type: Number } } },
   script_id: { type: Mongoose.Schema.ObjectId, required: true },
   queue_name: { type: String, required: true },
 });

--- a/server/src/scheduler/Queue.js
+++ b/server/src/scheduler/Queue.js
@@ -29,7 +29,6 @@ export type RoutineMutator = (routine: Routine) => Promise<Routine>;
 
 const Mongoose = require('mongoose');
 const RoutineModel = require('../model/Routine');
-const ScheduleModel = require('../model/Schedule');
 // Flow typeof won't work with import type
 const {Model} = require('mongoose');
 
@@ -94,27 +93,6 @@ class Queue {
 
   completeRoutine(routine: Routine): Promise<Routine> {
     return routine.update({ is_completed: true }).exec();
-  }
-
-  renewRoutine(routine: Routine): Promise<?Routine> {
-    const script_id: string = routine.get('script_id');
-    const schedule_id: string = routine.get('schedule_id');
-    const context_id: string = routine.get('context_id');
-
-    return ScheduleModel.findById(schedule_id).exec()
-      .then((schedule: ?Schedule) => {
-        if (schedule == null) {
-          return null;
-        }
-
-        const recurrence: ?number = schedule.get('recurrence');
-        if (recurrence == null || recurrence == 0) {
-          return null;
-        }
-
-        const date = new Date(routine.get('visible_from').getTime() + recurrence);
-        return this.createRoutine(script_id, schedule_id, context_id, date);
-      });
   }
 }
 

--- a/server/src/scheduler/utils/recurrences.js
+++ b/server/src/scheduler/utils/recurrences.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+
+export type Expression = Map<string, List<number>>;
+export type Extractor = () => number;
+export type FrameHashMap = Map<number, number>;
+export type Seeker = () => void;
+
+const {List, Map} = require('immutable');
+
+// To grant an expression repeating in time will need:
+//
+// 7: leap-years blocks
+// 1461 = 365 * 4 + 1: days in a leap-year block
+// 86400 = 24 * 60 * 60: seconds in a day
+// 1000: bacause javascript...
+const MAX_CALENDAR_UNIQUENESS_WINDOW_MS = 883612800000;
+
+const get_hmaps = function(expression: Expression): Map<string, FrameHashMap> {
+  return expression.map((frame: List<number>) => {
+    return Map(frame.toSet().sort().toList().map((unit: number) => [unit, unit]).toSeq());
+  });
+};
+
+const match_frame = function(hmap: FrameHashMap, extractor: Extractor): bool {
+  return hmap.size === 0 || hmap.has(extractor());
+};
+
+const skip_frames = function(hmap: FrameHashMap, extractor: Extractor, seeker: Seeker): bool {
+  if (!match_frame(hmap, extractor)) {
+    seeker();
+    return true;
+  }
+  return false;
+};
+
+const get_next_schedule_date_from_expression = function(since: Date, expression: Expression): Date {
+  const hmaps = get_hmaps(expression);
+  const next = new Date(since);
+  next.setMinutes(next.getMinutes() + 1, 0, 0);
+
+  const seekers = new List([
+    () => skip_frames(hmaps.get('months', new Map()), () => next.getMonth(), () => {
+      next.setMonth(next.getMonth() + 1, 1);
+      next.setHours(0, 0);
+    }),
+    () => skip_frames(hmaps.get('days', new Map()), () => next.getDate(), () => {
+      next.setDate(next.getDate() + 1);
+      next.setHours(0, 0);
+    }),
+    () => skip_frames(hmaps.get('week_days', new Map()), () => next.getDay(), () => {
+      next.setDate(next.getDate() + 1);
+      next.setHours(0, 0);
+    }),
+    () => skip_frames(hmaps.get('hours', new Map()), () => next.getHours(), () => {
+      next.setHours(next.getHours() + 1, 0);
+    }),
+    () => skip_frames(hmaps.get('minutes', new Map()), () => next.getMinutes(), () => {
+      next.setMinutes(next.getMinutes() + 1, 0);
+    }),
+  ]);
+
+  while (next - since <= MAX_CALENDAR_UNIQUENESS_WINDOW_MS) {
+    if (seekers.findIndex((seeker: Seeker) => seeker()) === - 1) {
+      return next;
+    }
+  }
+
+  throw new Error('No occurrence will exists for the provided recurrence expression');
+};
+
+module.exports = {
+  MAX_CALENDAR_UNIQUENESS_WINDOW_MS: MAX_CALENDAR_UNIQUENESS_WINDOW_MS,
+  get_next_schedule_date_from_expression: get_next_schedule_date_from_expression,
+};

--- a/server/src/server/controllers/schedule/ScheduleCreateController.js
+++ b/server/src/server/controllers/schedule/ScheduleCreateController.js
@@ -32,14 +32,12 @@ const AbstractDocumentCreateController = require('../AbstractDocumentCreateContr
 const DateParam = require('../../params/DateParam');
 const BooleanParam = require('../../params/BooleanParam');
 const HttpStatus = require('http-status-codes');
-const IntegerParam = require('../../params/IntegerParam');
-const OrParam = require('../../params/OrParam');
 const MongoIdParam = require('../../params/MongoIdParam');
+const ScheduleRecurrenceParam = require('../../params/ScheduleRecurrenceParam');
 const ScheduleModel = require('../../../model/Schedule');
 const ScriptModel = require('../../../model/Script');
 const StringParam = require('../../params/StringParam');
 const QueueNameParam = require('../../params/QueueNameParam');
-const {List} = require('immutable');
 
 class ScheduleCreateController extends AbstractDocumentCreateController {
 
@@ -57,10 +55,7 @@ class ScheduleCreateController extends AbstractDocumentCreateController {
       context_id: new StringParam().setMinLength(1).setDefaultValue(ctx_id),
       start_time: new DateParam().setDefaultValue(new Date()),
       is_paused: new BooleanParam().setDefaultValue(false),
-      recurrence: new OrParam(new List([
-        new IntegerParam().setMin(3600000), // 1h min intval,
-        new IntegerParam().setMin(0).setMax(0)
-      ])).setDefaultValue(0).optional(),
+      recurrence: new ScheduleRecurrenceParam().optional(),
       script_id: new MongoIdParam(),
       queue_name: new QueueNameParam(this.getApplication().getScheduler()),
     });
@@ -69,12 +64,13 @@ class ScheduleCreateController extends AbstractDocumentCreateController {
   genResponse(context: Context): void {
     const scheduler = this.getApplication().getScheduler();
     const script_id = context.getParams().getString('script_id');
+    const recurrence = context.getParams().getOptionalMap('recurrence');
     const schedule = ScheduleModel({
       context_id: context.getParams().getString('context_id'),
       start_time: context.getParams().getDate('start_time'),
       is_paused: context.getParams().getBoolean('is_paused'),
       queue_name: context.getParams().getString('queue_name'),
-      recurrence: context.getParams().getOptionalNumber('recurrence'),
+      recurrence: recurrence == null ? null : recurrence.toJS(),
       script_id: script_id,
     });
 

--- a/server/src/server/params/ScheduleRecurrenceParam.js
+++ b/server/src/server/params/ScheduleRecurrenceParam.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+
+const AbstractJsonParam = require('./AbstractJsonParam');
+const IntegerParam = require('./IntegerParam');
+const {List, Map, Set} = require('immutable');
+const {genMap, genSet} = require('../../utils/promises');
+const {get_next_schedule_date_from_expression} = require('../../scheduler/utils/recurrences');
+
+const MIN_ALLOWED_INTERVAL_MS = 3600000; // 1 hour
+
+class ScheduleRecurrenceParam extends AbstractJsonParam<Object> {
+
+  getValidator(param: IntegerParam): (subject: any) => Promise<List<number>> {
+    return (subject: any): Promise<List<number>> => {
+      return subject instanceof Array
+        ? genSet(new Set(subject).map((unit: any) => param.willValidate(unit)))
+          .then((set: Set<number>) => set.sort().toList())
+        : subject == null ? Promise.resolve(new List()) : Promise.reject(new Error('not an array'));
+    };
+  }
+
+  willValidate(value: any): Promise<Map<string, List<number>>> {
+    return super.willValidate(value).then((subject: Object) => {
+      const input = new Map(subject);
+      const subs = new Map({
+        minutes: new IntegerParam().setMin(0).setMax(59),
+        hours: new IntegerParam().setMin(0).setMax(23),
+        days: new IntegerParam().setMin(1).setMax(31),
+        week_days: new IntegerParam().setMin(0).setMax(6),
+        months: new IntegerParam().setMin(0).setMax(11),
+      });
+
+      return genMap(subs.map((param: IntegerParam, frame: string) => {
+        return this.getValidator(param)(input.get(frame, []))
+          .catch((error: Error) => Promise.reject(new Error(`'${frame}' frame: ${error.message}`)));
+      }))
+        .then((recurrence: Map<string, List<number>>) => {
+          const now = new Date();
+          const next = get_next_schedule_date_from_expression(now, recurrence);
+          const another = get_next_schedule_date_from_expression(next, recurrence);
+
+          return another - next < MIN_ALLOWED_INTERVAL_MS
+            ? Promise.reject(new Error(
+              `Recurrence doens't meet expected minimum routine inteval of ${MIN_ALLOWED_INTERVAL_MS} ms`
+            ))
+            : recurrence;
+        });
+    });
+  }
+}
+
+module.exports = ScheduleRecurrenceParam;

--- a/server/src/utils/promises.js
+++ b/server/src/utils/promises.js
@@ -22,7 +22,7 @@
  * @flow
  */
 
-const {List, Map} = require('immutable');
+const {List, Map, Set} = require('immutable');
 
 export type Promisable<T> = Promise<T> | T;
 export type Resolve<T> = (result: Promisable<T>) => void;
@@ -42,8 +42,14 @@ const genMap = function<T>(promises: Map<string, Promisable<T>>): Promise<Map<st
   ));
 };
 
+const genSet = function<T>(promises: Set<Promisable<T>>): Promise<Set<T>> {
+  return genList(promises.toList())
+    .then((list: List<T>) => list.toSet());
+};
+
 module.exports = {
+  genArray: Promise.all,
   genList: genList,
   genMap: genMap,
-  genArray: Promise.all,
+  genSet: genSet,
 };


### PR DESCRIPTION
Fields:
1. All fields accepts array of integers
2. Omitting a field or using an empty array signals an 'All' (\* in crontab standard)
3. Same format applies for updating: POST /schedules/<SCHEDULE_ID>
- days_of_week: 0-6 (0 = Sunday)
- months: 0-11 (0 = Jan)
- days_of_month: 1-31
- hours: 0-23
- minutes: 0-59

The following request will schedule a routine to run every Monday at
00:00, 00:30, 12:00 and 12:30

``` bash
curl -X POST \
  -H "Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW"
  -F "script_id=<SCRIPT_ID>"
  -F "access_token=<ACCESS_TOKEN>"
  -F "recurrence_spec={'days_of_week': [1], 'hours': [0,12], 'minutes': [0, 30]}"
  -F "queue_name=main"
  "https://typefast.vm/schedules"
```
