### PR TITLE
[Server] Deprecate babel polyfill + Improve Worker logs

### DIFF
--- a/sdk/.babelrc
+++ b/sdk/.babelrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["transform-flow-strip-types"]
+  "plugins": ["transform-flow-strip-types"],
+  "retainLines": true
 }

--- a/server/.babelrc
+++ b/server/.babelrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["transform-flow-strip-types"]
+  "plugins": ["transform-flow-strip-types"],
+  "retainLines": true
 }

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -10,6 +10,7 @@
       "bundle": null
     }
   },
+  "interpreter": "node",
   "server": {
     "client": {
       "enable_delivery": true,

--- a/server/index.js
+++ b/server/index.js
@@ -23,12 +23,10 @@
 const parseArgv = require('minimist');
 const {List, Map} = require('immutable');
 
-const TRANSPILE_KEY = 'transpile';
 const MODE_KEY = 'mode';
 const DEFAULT_MODE = 'server';
 
 const passthrou_exclude = new List([
-  TRANSPILE_KEY,
   MODE_KEY
 ]);
 
@@ -37,10 +35,6 @@ const main = function(argv /* :List */) {
     .rest()
     .map(value => value instanceof Array ? value.pop() : value);
 
-  if (opts.get(TRANSPILE_KEY, false)) {
-    require('babel-register');
-    require('babel-polyfill');
-  }
   const mode = opts.get(MODE_KEY, DEFAULT_MODE);
 
   argv = opts.filterNot((value, key) => passthrou_exclude.keyOf(key) != null);

--- a/server/package.json
+++ b/server/package.json
@@ -4,28 +4,25 @@
   "description": "TypeFast Server application",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint src/",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "transpile": "babel src/ -d build/",
-    "start": "node index.js --mode=server",
-    "dev": "nodemon index.js --transpile --inline-config='{\"debug\": true}'",
-    "worker": "npm start -- --mode=worker",
-    "dev-worker": "npm start -- --transpile --mode=worker",
     "definition-generation": "node bin/fbTypesGenerator.js",
-    "debug": "node debug index.js --transpile"
+    "dev": "nodemon index.js --exec babel-node --mode=server --inline-config='{\"interpreter\": \"babel-node\", \"debug\": true}'",
+    "lint": "eslint src/",
+    "start": "node index.js --mode=server",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "transpile": "babel src/ -d build/"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pruno/typefast.git"
+    "url": "git+https://github.com/facebook/typefast.git"
   },
   "author": {
     "name": "Luca Bruno",
     "url": "https://github.com/pruno"
   },
   "bugs": {
-    "url": "https://github.com/pruno/typefast/issues"
+    "url": "https://github.com/facebook/typefast/issues"
   },
-  "homepage": "https://github.com/pruno/typefast#readme",
+  "homepage": "https://github.com/facebook/typefast#readme",
   "engines": {
     "node": ">=6.0.0"
   },
@@ -50,11 +47,9 @@
     "babel-eslint": "~6.0.4",
     "babel-plugin-syntax-flow": "~6.8.0",
     "babel-plugin-transform-flow-strip-types": "~6.8.0",
-    "babel-polyfill": "~6.8.0",
-    "babel-register": "~6.9.0",
     "eslint": "~2.10.2",
     "eslint-plugin-flowtype": "~2.2.7",
     "fbjs-scripts": "~0.7.0",
-    "nodemon": "~1.9.2"
+    "nodemon": "~1.10.0"
   }
 }

--- a/server/src/bootstraps/server.js
+++ b/server/src/bootstraps/server.js
@@ -33,7 +33,7 @@ const getControllers = require('../server/controllersFactory');
 const bootstrap = function(argv: Argv): Application {
   const app = new Application(Config.fromArgv(argv));
   getControllers(app).forEach(controller => app.getRouter().mountCountroller(controller));
-  app.on(Application.events.INIT, (drivers: Map<string, AbstractDriver>) => {
+  app.once(Application.events.INIT, (drivers: Map<string, AbstractDriver>) => {
     drivers.map((driver: AbstractDriver, key: string) => {
       const listener = driver.getListenerDescription();
       console.log(`Server listening on [${key}]: ${listener}`);


### PR DESCRIPTION
- Implement startup scripts with babel-node
- Cleanup --transpile flags
- Propagate interpreter choice through config
- Provide startup information for Worker
