### PR TITLE
Documentation update

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,3 +1,2 @@
-/build
+src/build
 src/js/tern/fb_defs.js
-TODO

--- a/client/README.md
+++ b/client/README.md
@@ -1,28 +1,48 @@
-#Client Development ReadMe
+# TypeFast Client
 
-##Development
+# Requirements
 
-**Before getting started with client side development, make sure to have the [Server](../server/README.md) setup and running and the [SDK](../sdk/README.md)**
+* [Node.js](https://nodejs.org/) 6.0.0+
+
+# Install
+
+**Before getting started with client side development, make sure to have the [Server](../server/README.md) setup and running and the [SDK](../sdk/README.md).**
+
+### Install Dependencies
+
+    npm install
+
+### Generate Definitions
+
+When using our Graph API or SDKs you have to declare in advance which fields you are wanting to access on the object. One of the simplifications TypeFast makes is by statically analysing the code that has been written, we can work this out and seamlessly get the fields you need.
+
+Generate these definitions:
+
+    npm run definition-generation
+
+### Build
+
+    mkdir -p src/build
+    npm run build
+
+# Run
+
+Once the TypeFast server is running, you can access the client via https://localhost:8080. Make sure that the domain you are using matches one of the *App Domains* in your [app manager](https://developers.facebook.com/apps/) (under settings).
+
+### From source - Reloading on file changes
 
 TypeFast use a build tool chain to package and transpile all the JSX files and ES6 javascript into a single file. When developing on the UI you can make sure that any changes to the source file are automatically recompiled by running the following commands from the client directory root:
 
 ```
-  npm install
   npm run watch
 ```
 
-##Activating Auto Complete and Optimisations
-
-When using our Graph API or SDKs you have to declare in advance which fields you are wanting to access on the object. One of the simplifications TypeFast makes is by statically analysing the code that has been written, we can work this out and seamlessly get the fields you have access.
-
-Before Starting Type Fast you will need to generate these definitions by running the command from **the server root directory**
-
-```
-  npm run definition-generation
-```
-
-##How things are built
+# Development Notes
 
 The client side is all built using Redux and React Bootstrap. Redux means the app has a uni directional data flow. Components trigger actions -> actions trigger state changes -> and state changes update components. Read up on Redux to understand more about how the app is architected.
 
 http://redux.js.org/
+
+# License
+
+This software is released under the [Facebook Platform License](https://github.com/facebook/typefast/blob/master/LICENSE).

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,17 +12,17 @@ TypeFast SDK is the barebone user-space abstraction available within TypeFast wo
 
     npm install
 
-### Transpile for packaging
-
-To transpile the source and exit:
-
-    npm run-script transpile
-
 # Tests with [Jest](https://facebook.github.io/jest/)
 
     npm test
 
-Note: HTML code coverage files will be built within the `./typefaast/coverage/`
+Note: HTML code coverage files will be built within the `./typefast/coverage/`
+
+# [Optional] Transpile for packaging
+
+To transpile the source and exit:
+
+    npm run-script transpile
 
 # License
 

--- a/server/README.md
+++ b/server/README.md
@@ -25,24 +25,45 @@ TypeFast Server is the backend responsible for:
     mkdir ssl && cd ssl
     openssl req -x509 -newkey rsa:2048 -keyout key -out crt -days 365 -nodes
 
-#### Setup base configuration
+#### Setup configuration file
+
+Copy file:
 
     cp config/local.dist.json config/local.json
 
-Than edit `config/local.json`, filling all the keys.
+Then edit `config/local.json`, filling all the keys:
 
-Notes:
-  1. graph.schema.bundle -> absolute path to the provided schema bundle
+`application_id` and `application_secret` are available in the [App manager](https://developers.facebook.com/apps/) (under settings).
+
+For `access_token`, create a **admin system user** in business manager. (Remember you have to claim your app in business manager before you can create system users for it). Once you have created an admin system user, generate a token with the `ads_management` permission. Enter this token at `access_token`.
+
+For `business_manager_id` fill in your business_id. You can find this value in the url when you are in business manager.
+
+For `bundle`, provide the absolute path to the provided schema bundle (provided by your FB POC).
 
 # Run
 
-### From source
+You will need to run a TypeFast server and a TypeFast worker.
 
-    npm start
+## Server
+
+### from source
+
+    npm run server
 
 ### From source - Reloading on file changes [dev-only]
 
-    npm run dev
+    npm run dev-server
+
+## Worker
+
+### from source
+
+    npm run worker
+
+### From source - Reloading on file changes [dev-only]
+
+    npm run dev-worker
 
 # [Optional] Transpile for packaging
 

--- a/server/package.json
+++ b/server/package.json
@@ -5,8 +5,12 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon index.js --exec babel-node --mode=server --inline-config='{\"interpreter\": \"babel-node\", \"debug\": true}'",
+    "dev-server": "npm run dev",
+    "dev-worker": "npm run dev -- --mode=worker",
     "lint": "eslint src/",
     "start": "babel-node index.js --mode=server --inline-config='{\"interpreter\": \"babel-node\"}'",
+    "server": "npm start",
+    "worker": "npm start -- --mode=worker",
     "test": "echo \"Error: no test specified\" && exit 1",
     "transpile": "babel src/ -d build/"
   },


### PR DESCRIPTION
Made server/readme.md, sdk/readme.md client/readme.md more consistent (intro, requirements, install, run, optional, licence)

Fixed typos

Updated development instructions (eg definitions should be generated in the client directory, client needs a src/build directory, we also need a running worker etc)

Updated server/package.json scripts to support starting a worker
npm run server
npm run worker
npm run dev-server
npm run dev-worker
