### PR TITLE
[WIP] Prompt users before changing script view

### DIFF
--- a/client/src/js/actions/actions.js
+++ b/client/src/js/actions/actions.js
@@ -231,12 +231,34 @@ export function hideHelpModal() {
   };
 }
 
+/******************************** UNSAVED CHANGES *****************************/
+
+export const SHOW_UNSAVED_CHANGES_DIALOG = 'SHOW_UNSAVED_CHANGES_DIALOG';
+export function showUnsavedChangesDialog(pendingAction) {
+  return {
+    type: SHOW_UNSAVED_CHANGES_DIALOG,
+    payload: {
+      pendingAction: pendingAction
+    }
+  }
+}
+
+export const HIDE_UNSAVED_CHANGES_DIALOG = 'HIDE_UNSAVED_CHANGES_DIALOG';
+export function hideUnsavedChangesDialog() {
+  return {
+    type: HIDE_UNSAVED_CHANGES_DIALOG
+  }
+}
+
 /******************************** NEW SCRIPT **********************************/
 
 export const SHOW_NEW_SCRIPT_DIALOG = 'SHOW_NEW_SCRIPT_DIALOG';
 export function showNewScriptDialog() {
   return {
-    type: SHOW_NEW_SCRIPT_DIALOG
+    type: SHOW_NEW_SCRIPT_DIALOG,
+    meta: {
+      checkUnsavedChanges: true
+    }
   };
 }
 

--- a/client/src/js/components/TypeFastApp.js
+++ b/client/src/js/components/TypeFastApp.js
@@ -31,6 +31,7 @@ import TypeFastAppBarContainer from '../containers/TypeFastAppBarContainer';
 import TypeFastHelpContainer from '../containers/TypeFastHelpContainer';
 import TypeFastHistoryContainer from '../containers/TypeFastHistoryContainer';
 import TypeFastLoaderContainer from '../containers/TypeFastLoaderContainer';
+import TypeFastUnsavedChangesContainer from '../containers/TypeFastUnsavedChangesContainer';
 import TypeFastNewScriptContainer from '../containers/TypeFastNewScriptContainer';
 import TypeFastOpenScriptContainer from '../containers/TypeFastOpenScriptContainer';
 import TypeFastScheduleContainer from '../containers/TypeFastScheduleContainer';
@@ -52,6 +53,7 @@ class TypeFastApp extends React.Component {
 
         <TypeFastHelpContainer />
         <TypeFastHistoryContainer />
+        <TypeFastUnsavedChangesContainer />
         <TypeFastNewScriptContainer />
         <TypeFastOpenScriptContainer />
         <TypeFastScheduleContainer />

--- a/client/src/js/components/TypeFastUnsavedChangesDialog.js
+++ b/client/src/js/components/TypeFastUnsavedChangesDialog.js
@@ -22,35 +22,45 @@
  * @flow
  */
 
-import thunkMiddleware from 'redux-thunk';
-import { createStore, applyMiddleware } from 'redux';
-import rootReducer from './reducers/reducers.js';
-import { Provider } from 'react-redux';
 import React from 'react';
-import ReactDOM from 'react-dom';
-import TypeFastApp from './components/TypeFastApp';
-import { serverConfig } from './ServerConfig';
-import injectTapEventPlugin from 'react-tap-event-plugin';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import typeFastUnsavedChangesMiddleware from './middleware/TypeFastUnsavedChangesMiddleware';
 
-injectTapEventPlugin();
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
+import FontIcon from 'material-ui/FontIcon';
 
-const store = createStore(
-  rootReducer,
-  applyMiddleware(
-    thunkMiddleware,
-    typeFastUnsavedChangesMiddleware
-  )
-);
+class TypeFastUnsavedChangesDialog extends React.Component {
+  render() {
+    const actions = [
+      <FlatButton
+        label="Cancel"
+        secondary={true}
+        onTouchTap={this.props.onHide.bind(this)}
+      />,
+      <FlatButton
+        label="Don't Save"
+        secondary={true}
+        onTouchTap={this.props.onDontSave.bind(this)}
+      />,
+      <FlatButton
+        label="Save"
+        primary={true}
+        onTouchTap={this.props.onSave.bind(this)}
+      />
+    ];
+    return (
+      <Dialog
+        title="You have unsaved changes"
+        actions={actions}
+        modal={false}
+        open={this.props.isShowing}
+        onRequestClose={this.props.onHide}
+      >
+        <div>
+          holla
+        </div>
+      </Dialog>
+    );
+  }
+}
 
-serverConfig.fetch(function() {
-  ReactDOM.render(
-    <Provider store={store}>
-      <MuiThemeProvider>
-        <TypeFastApp />
-      </MuiThemeProvider>
-    </Provider>,
-    document.getElementById('typefast')
-  );
-});
+module.exports = TypeFastUnsavedChangesDialog;

--- a/client/src/js/containers/TypeFastUnsavedChangesContainer.js
+++ b/client/src/js/containers/TypeFastUnsavedChangesContainer.js
@@ -22,35 +22,40 @@
  * @flow
  */
 
-import thunkMiddleware from 'redux-thunk';
-import { createStore, applyMiddleware } from 'redux';
-import rootReducer from './reducers/reducers.js';
-import { Provider } from 'react-redux';
-import React from 'react';
-import ReactDOM from 'react-dom';
-import TypeFastApp from './components/TypeFastApp';
-import { serverConfig } from './ServerConfig';
-import injectTapEventPlugin from 'react-tap-event-plugin';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import typeFastUnsavedChangesMiddleware from './middleware/TypeFastUnsavedChangesMiddleware';
+import { connect } from 'react-redux';
+import {
+  saveScript,
+  hideUnsavedChangesDialog
+} from '../actions/actions.js';
+import TypeFastUnsavedChangesDialog from '../components/TypeFastUnsavedChangesDialog';
 
-injectTapEventPlugin();
+const mapStateToProps = (state, ownProps) => {
+  return {
+    isShowing: state.showUnsavedChangesDialog,
+    pendingAction: state.pendingAction
+  };
+};
 
-const store = createStore(
-  rootReducer,
-  applyMiddleware(
-    thunkMiddleware,
-    typeFastUnsavedChangesMiddleware
-  )
-);
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    onHide() {
+      dispatch(hideUnsavedChangesDialog());
+    },
+    onDontSave() {
+      dispatch(hideUnsavedChangesDialog());
+      dispatch(this.props.pendingAction);
+    },
+    onSave() {
+      dispatch(saveScript());
+      dispatch(hideUnsavedChangesDialog());
+      dispatch(this.props.pendingAction);
+    },
+  };
+};
 
-serverConfig.fetch(function() {
-  ReactDOM.render(
-    <Provider store={store}>
-      <MuiThemeProvider>
-        <TypeFastApp />
-      </MuiThemeProvider>
-    </Provider>,
-    document.getElementById('typefast')
-  );
-});
+const TypeFastUnsavedChangesContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TypeFastUnsavedChangesDialog);
+
+export default TypeFastUnsavedChangesContainer;

--- a/client/src/js/middleware/TypeFastUnsavedChangesMiddleware.js
+++ b/client/src/js/middleware/TypeFastUnsavedChangesMiddleware.js
@@ -1,0 +1,21 @@
+import { showUnsavedChangesDialog } from '../actions/actions.js'
+
+const unsavedChanges = store => next => action => {
+  let result;
+
+  if ( action.meta && action.meta.checkUnsavedChanges && store.getState().needToSave ) {
+    // unsaved data - show dialog before continuing
+    const pendingAction = Object.assign({}, action, {
+      meta : {
+        checkUnsavedChanges: false
+      }
+    });
+    result = store.dispatch(showUnsavedChangesDialog(pendingAction))
+  } else {
+    result = next(action)
+  }
+
+  return result
+}
+
+module.exports = unsavedChanges

--- a/client/src/js/reducers/reducers.js
+++ b/client/src/js/reducers/reducers.js
@@ -46,6 +46,9 @@ import {
   SHOW_HELP_MODAL,
   HIDE_HELP_MODAL,
 
+  SHOW_UNSAVED_CHANGES_DIALOG,
+  HIDE_UNSAVED_CHANGES_DIALOG,
+
   SHOW_NEW_SCRIPT_DIALOG,
   HIDE_NEW_SCRIPT_DIALOG,
   LOAD_SAMPLE,
@@ -98,7 +101,7 @@ function typefastApp(state = {
   log: initialLog(),
   runHistory: {},
 
-  needToSave: true,
+  needToSave: false,
   currentScript: defaultScript(),
   currentScriptTitle: defaultScript().title,
   currentSchedule: defaultSchedule(),
@@ -109,6 +112,7 @@ function typefastApp(state = {
 
   samples: [],
   showHelpModal: false,
+  showUnsavedChangesDialog: false,
   showRunHistoryModal: false,
   showOpenScriptDialog: false,
   showNewScriptDialog: false,
@@ -519,6 +523,20 @@ utils.xmlParser(xml.body, function(err, data) {
     case HIDE_HELP_MODAL: {
       return Object.assign({}, state, {
         showHelpModal: false,
+      });
+    }
+
+    case SHOW_UNSAVED_CHANGES_DIALOG: {
+      return Object.assign({}, state, {
+        showUnsavedChangesDialog: true,
+        pendingAction: action.payload.pendingAction
+      });
+    }
+
+    case HIDE_UNSAVED_CHANGES_DIALOG: {
+      return Object.assign({}, state, {
+        showUnsavedChangesDialog: false,
+        pendingAction: undefined
       });
     }
 


### PR DESCRIPTION
Use metadata on actions (to mark the ones that change the script view)
Use middleware to show the unsaved changes dialog on those actions (but only if there is unsaved content) before executing the original requested action.

Currently POC that only works with the 'new script' action. To test:
1. get the code
2. run TypeFast
3. edit a script
4. select 'new script'
5. see the dialog
6. try all three buttons (don't save, save, cancel).

Relatively new to Redux (and React/Flux) so please share if there are better ways!
